### PR TITLE
docs(readme): document vhosts clean/cleanup

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -299,6 +299,17 @@ Example Pillar:
           SSLCertificateKeyFile: /path/to/ssl.key
           SSLCertificateChainFile: /path/to/ssl.ca.crt
 
+``apache.config.vhosts.clean``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remove non-declared virtual hosts, and deactivates the service.
+
+``apache.config.vhosts.cleanup``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remove non-declared virtual hosts, but keeps the service running.
+
+
 Testing
 -------
 


### PR DESCRIPTION
Linked to #372

Properly document ``apache.config.vhosts.clean`` and ``apache.config.vhosts.cleanup``, and the differences between them.